### PR TITLE
feat: add CI/CD pipeline and update module imports

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,0 +1,42 @@
+name: 'Setup Python Environment'
+description: 'Setup Python with uv and cache dependencies'
+
+inputs:
+  python-version:
+    description: 'Python version to use'
+    required: false
+    default: '3.13'
+  uv-version:
+    description: 'uv version to use'
+    required: false
+    default: '0.8.13'
+  cache-key:
+    description: 'Cache key for dependencies'
+    required: false
+    default: 'venv'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: ${{ inputs.uv-version }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: ${{ runner.os }}-${{ inputs.cache-key }}-venv-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cache-key }}-venv-
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        uv sync --group dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 
 env:
   UV_VERSION: "0.8.13"
+  MIN_COVERAGE: 0
+  PYTHON_VERSION: "3.13"  # Default Python version for non-matrix jobs
+  PYTHON_VERSIONS: '["3.9", "3.10", "3.11", "3.12", "3.13"]'  # Python versions for matrix testing
 
 jobs:
   lint:
@@ -20,27 +23,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+    - name: Setup Python Environment
+      uses: ./.github/actions/setup-python
       with:
-        python-version: "3.13"
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@v6
-      with:
-        version: ${{ env.UV_VERSION }}
-
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: .venv
-        key: ${{ runner.os }}-venv-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-venv-
-
-    - name: Install dependencies
-      run: |
-        uv sync --group dev
+        python-version: ${{ env.PYTHON_VERSION }}
+        uv-version: ${{ env.UV_VERSION }}
 
     - name: Run linting
       run: |
@@ -62,27 +49,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+    - name: Setup Python Environment
+      uses: ./.github/actions/setup-python
       with:
-        python-version: "3.13"
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@v6
-      with:
-        version: ${{ env.UV_VERSION }}
-
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: .venv
-        key: ${{ runner.os }}-venv-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-venv-
-
-    - name: Install dependencies
-      run: |
-        uv sync --group dev
+        python-version: ${{ env.PYTHON_VERSION }}
+        uv-version: ${{ env.UV_VERSION }}
 
     - name: Run type checking
       run: |
@@ -92,36 +63,22 @@ jobs:
     name: Tests
     runs-on: ${{ matrix.os }}
     needs: [lint, type-check]
+    timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ fromJson(env.PYTHON_VERSIONS) }}
         os: [ubuntu-latest, macos-latest]
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - name: Setup Python Environment
+      uses: ./.github/actions/setup-python
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@v6
-      with:
-        version: ${{ env.UV_VERSION }}
-
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: .venv
-        key: ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.python-version }}-venv-
-
-    - name: Install dependencies
-      run: |
-        uv sync --group dev
+        uv-version: ${{ env.UV_VERSION }}
+        cache-key: ${{ matrix.python-version }}
 
     - name: Run tests with coverage
       run: |
@@ -130,6 +87,10 @@ jobs:
     - name: Generate coverage report
       run: |
         uv run make report-tests
+
+    - name: Check coverage threshold
+      run: |
+        uv run coverage report --show-missing --fail-under=${{ env.MIN_COVERAGE }}
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
@@ -143,75 +104,56 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     needs: test
+    timeout-minutes: 15
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+    - name: Setup Python Environment
+      uses: ./.github/actions/setup-python
       with:
-        python-version: "3.13"
+        python-version: ${{ env.PYTHON_VERSION }}
+        uv-version: ${{ env.UV_VERSION }}
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v6
-      with:
-        version: ${{ env.UV_VERSION }}
-
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: .venv
-        key: ${{ runner.os }}-venv-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-venv-
-
-    - name: Install dependencies
-      run: |
-        uv sync --group dev
-
-    - name: Run security scan with bandit
+    - name: Run bandit security scan
       run: |
         uv run pip install bandit
         uv run bandit -r risk_control/ -f json -o bandit-report.json || true
+
+    - name: Run pip-audit for dependency vulnerabilities
+      run: |
+        uv run pip install pip-audit
+        uv run pip-audit --format json --output pip-audit-report.json || true
 
     - name: Upload security scan results
       uses: actions/upload-artifact@v4
       with:
         name: security-scan-results
-        path: bandit-report.json
+        path: |
+          bandit-report.json
+          pip-audit-report.json
 
   docs:
     name: Build Documentation
     runs-on: ubuntu-latest
     needs: [test, security]
     if: github.event_name == 'release'
+    timeout-minutes: 20
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+    - name: Setup Python Environment
+      uses: ./.github/actions/setup-python
       with:
-        python-version: "3.13"
+        python-version: ${{ env.PYTHON_VERSION }}
+        uv-version: ${{ env.UV_VERSION }}
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v6
-      with:
-        version: ${{ env.UV_VERSION }}
-
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: .venv
-        key: ${{ runner.os }}-venv-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-venv-
-
-    - name: Install dependencies
+    - name: Install documentation dependencies
       run: |
-        uv sync --group dev --group docs
+        uv sync --group docs
 
     - name: Build documentation
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,12 +92,13 @@ jobs:
         uv run coverage report --show-missing --fail-under=${{ env.MIN_COVERAGE }}
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}  # Optional: Add if you have a token
 
   security:
     name: Security Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ env:
   UV_VERSION: "0.8.13"
   MIN_COVERAGE: 0
   PYTHON_VERSION: "3.13"  # Default Python version for non-matrix jobs
-  PYTHON_VERSIONS: '["3.9", "3.10", "3.11", "3.12", "3.13"]'  # Python versions for matrix testing
 
 jobs:
   lint:
@@ -66,7 +65,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ${{ fromJson(env.PYTHON_VERSIONS) }}
+        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,224 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [published]
+
+env:
+  UV_VERSION: "0.8.13"
+
+jobs:
+  lint:
+    name: Lint and Format
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: ${{ env.UV_VERSION }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-
+
+    - name: Install dependencies
+      run: |
+        uv sync --group dev
+
+    - name: Run linting
+      run: |
+        uv run make lint
+
+    - name: Check code formatting
+      run: |
+        uv run make format
+
+    - name: Run pre-commit hooks
+      run: |
+        uv run make pre-commit
+
+  type-check:
+    name: Type Checking
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: ${{ env.UV_VERSION }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-
+
+    - name: Install dependencies
+      run: |
+        uv sync --group dev
+
+    - name: Run type checking
+      run: |
+        uv run make type-check
+
+  test:
+    name: Tests
+    runs-on: ${{ matrix.os }}
+    needs: [lint, type-check]
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: ${{ env.UV_VERSION }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.python-version }}-venv-
+
+    - name: Install dependencies
+      run: |
+        uv sync --group dev
+
+    - name: Run tests with coverage
+      run: |
+        uv run make tests
+
+    - name: Generate coverage report
+      run: |
+        uv run make report-tests
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: ${{ env.UV_VERSION }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-
+
+    - name: Install dependencies
+      run: |
+        uv sync --group dev
+
+    - name: Run security scan with bandit
+      run: |
+        uv run pip install bandit
+        uv run bandit -r risk_control/ -f json -o bandit-report.json || true
+
+    - name: Upload security scan results
+      uses: actions/upload-artifact@v4
+      with:
+        name: security-scan-results
+        path: bandit-report.json
+
+  docs:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    needs: [test, security]
+    if: github.event_name == 'release'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: ${{ env.UV_VERSION }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-
+
+    - name: Install dependencies
+      run: |
+        uv sync --group dev --group docs
+
+    - name: Build documentation
+      run: |
+        uv run make docs
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./site

--- a/.github/workflows/setup-python.yml
+++ b/.github/workflows/setup-python.yml
@@ -1,0 +1,49 @@
+name: Setup Python Environment
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: 'Python version to use'
+        required: false
+        default: '3.13'
+        type: string
+      cache-key:
+        description: 'Cache key for dependencies'
+        required: false
+        default: 'venv'
+        type: string
+    outputs:
+      python-version:
+        description: 'The Python version that was set up'
+        value: ${{ steps.setup-python.outputs.python-version }}
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ inputs.python-version }}
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ runner.os }}-${{ inputs.cache-key }}-venv-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ inputs.cache-key }}-venv-
+
+      - name: Install dependencies
+        run: |
+          uv sync --group dev

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, Risk Control Project Contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Risk Control Project
 
-[![CI/CD Pipeline](https://github.com/your-username/risk-control/workflows/CI%2FCD%20Pipeline/badge.svg)](https://github.com/your-username/risk-control/actions)
-[![Code Coverage](https://codecov.io/gh/your-username/risk-control/branch/main/graph/badge.svg)](https://codecov.io/gh/your-username/risk-control)
+[![CI/CD Pipeline](https://github.com/thibaultcordier/risk-control/workflows/CI%2FCD%20Pipeline/badge.svg)](https://github.com/thibaultcordier/risk-control/actions)
+[![Code Coverage](https://codecov.io/gh/thibaultcordier/risk-control/branch/main/graph/badge.svg)](https://codecov.io/gh/thibaultcordier/risk-control)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI/CD Pipeline](https://github.com/thibaultcordier/risk-control/workflows/CI%2FCD%20Pipeline/badge.svg)](https://github.com/thibaultcordier/risk-control/actions)
 [![Code Coverage](https://codecov.io/gh/thibaultcordier/risk-control/branch/main/graph/badge.svg)](https://codecov.io/gh/thibaultcordier/risk-control)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 This project focuses on developing and implementing risk control mechanisms for predictive algorithms based on the paper "Learn then test: Calibrating predictive algorithms to achieve risk control" by Angelopoulos et al. (2025).
 The primary goal is to ensure that the algorithms perform reliably and maintain a controlled level of risk.
@@ -43,7 +43,7 @@ uv run mkdocs serve
 
 ## License
 
-This project is licensed under the MIT License.
+This project is licensed under the BSD 3-Clause License. See the [LICENSE](LICENSE) file for details.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Risk Control Project
 
+[![CI/CD Pipeline](https://github.com/your-username/risk-control/workflows/CI%2FCD%20Pipeline/badge.svg)](https://github.com/your-username/risk-control/actions)
+[![Code Coverage](https://codecov.io/gh/your-username/risk-control/branch/main/graph/badge.svg)](https://codecov.io/gh/your-username/risk-control)
+[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 This project focuses on developing and implementing risk control mechanisms for predictive algorithms based on the paper "Learn then test: Calibrating predictive algorithms to achieve risk control" by Angelopoulos et al. (2025).
 The primary goal is to ensure that the algorithms perform reliably and maintain a controlled level of risk.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 [![Code Coverage](https://codecov.io/gh/thibaultcordier/risk-control/branch/main/graph/badge.svg)](https://codecov.io/gh/thibaultcordier/risk-control)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![PyPI version](https://badge.fury.io/py/doesnotyetexist.svg)](https://badge.fury.io/py/doesnotyetexist)
+[![Documentation](https://img.shields.io/badge/docs-mkdocs%20material-blue.svg?colorB=319795)](https://thibaultcordier.github.io/risk-control/)
+[![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-black.svg)](https://github.com/astral-sh/ruff)
+[![Linting: ruff](https://img.shields.io/badge/linting-ruff-red.svg)](https://github.com/astral-sh/ruff)
+[![Type checking: mypy](https://img.shields.io/badge/type%20checking-mypy-blue.svg)](https://mypy-lang.org/)
 
 This project focuses on developing and implementing risk control mechanisms for predictive algorithms based on the paper "Learn then test: Calibrating predictive algorithms to achieve risk control" by Angelopoulos et al. (2025).
 The primary goal is to ensure that the algorithms perform reliably and maintain a controlled level of risk.
@@ -34,7 +39,7 @@ uv run python examples/plot_classification_bis.py
 
 ## Documentation
 
-For detailed documentation, refer to the [docs](docs/index.md).
+For detailed documentation, refer to the [docs](https://thibaultcordier.github.io/risk-control/).
 
 Or you can build the documentation with:
 ```bash

--- a/risk_control/decision/__init__.py
+++ b/risk_control/decision/__init__.py
@@ -1,12 +1,12 @@
-from risk_control.decision.base import BaseDecision
-from risk_control.decision.classification import BaseClassificationDecision
-from risk_control.decision.decision import (
+from .base import BaseDecision
+from .classification import BaseClassificationDecision
+from .decision import (
     BestClassDecision,
     MultiLabelDecision,
     SelectiveClassification,
     SelectiveRegression,
 )
-from risk_control.decision.regression import (
+from .regression import (
     AdvancedRegressionDecision,
     BaseRegressionDecision,
 )

--- a/tests/test_ex.py
+++ b/tests/test_ex.py
@@ -1,9 +1,0 @@
-from unittest import TestCase
-
-
-class TestMySubModule(TestCase):
-    def test_add(self) -> None:
-        self.assertEqual(2 + 1, 3)
-
-    def test_sub(self) -> None:
-        self.assertEqual(3 - 2, 1)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import unittest
+
+# Add the project root to the path to allow direct imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestModuleImports(unittest.TestCase):
+    """Test cases for importing risk_control modules."""
+
+    def test_parameter_module(self) -> None:
+        """Test the parameter module directly."""
+        # Let's check what's available in parameter module
+        import risk_control.parameter
+
+        self.assertIsNotNone(risk_control.parameter)
+
+    def test_abstention_module(self) -> None:
+        """Test the abstention module directly."""
+        # Let's check what's available in abstention module
+        import risk_control.abstention
+
+        self.assertIsNotNone(risk_control.abstention)
+
+    def test_plot_module(self) -> None:
+        """Test the plot module directly."""
+        # Let's check what's available in plot module
+        import risk_control.plot
+
+        self.assertIsNotNone(risk_control.plot)
+
+    def test_risk_module(self) -> None:
+        """Test the risk module directly."""
+        # Let's check what's available in risk module
+        import risk_control.risk
+
+        self.assertIsNotNone(risk_control.risk)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Introduced a comprehensive CI/CD pipeline in `.github/workflows/ci.yml` for testing, linting, type checking, documentation building, and security scanning.
- Updated import statements in `risk_control/decision/__init__.py` to use relative imports.
- Removed obsolete test file `tests/test_ex.py` and added a new import validation test suite in `tests/test_imports.py`.